### PR TITLE
Fix DrawingLayer scaling mismatch

### DIFF
--- a/frontend/src/components/PdfViewer.tsx
+++ b/frontend/src/components/PdfViewer.tsx
@@ -182,8 +182,8 @@ export default function PdfViewer({
         {pageSize.width > 0 && pageSize.height > 0 && (
           <Box sx={{ position: 'absolute', top: 0, left: 0 }}>
             <DrawingLayer
-              width={pageSize.width * scale}
-              height={pageSize.height * scale}
+              width={pageSize.width}
+              height={pageSize.height}
               mode={mode}
               onSelectionComplete={onSelectionComplete || (() => {})}
             />


### PR DESCRIPTION
## Summary
- fix double scaling when drawing selection rectangles over PDFs

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685968b2a31c8320875d3b189e08f8c5